### PR TITLE
Add missing ! in shebang and use env for portability

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p ~/Library/Developer/Xcode/UserData/FontAndColorThemes/
 cp *.dvtcolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/


### PR DESCRIPTION
The install script is missing the `!` in the shebang. In addition, it should use `env` to determine the path of `bash`.