### PR TITLE
Add uninstallation script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+theme_dir=~/Library/Developer/Xcode/UserData/FontAndColorThemes
+
+for theme in *.dvtcolortheme; do
+	path=$theme_dir/$theme
+	if [[ -f "$path" ]]; then
+		echo "removing theme file $theme"
+		rm -f "$path"
+	fi
+done
+
+if [[ -d "$theme_dir" ]]; then
+	if [[ ! $(ls -A "$theme_dir") ]]; then
+		echo "removing empty theme dir $theme_dir"
+		rm -rf "$theme_dir"
+	else
+		echo "keeping non-empty theme dir $theme_dir"
+	fi
+else
+	echo "could not find any installed themes"
+fi


### PR DESCRIPTION
GIven that there is a script for easy installation of the themes, there should also be a way to automatically remove the installed themes. The script in this pull request scans the theme folder for any matching files and removes them. It also removes the theme folder itself in case it is empty.